### PR TITLE
Use async fs API and wait for all deletions

### DIFF
--- a/newspapers.ts
+++ b/newspapers.ts
@@ -33,13 +33,15 @@ export const getDirectoryContents = async (dir: string): Promise<string[]> => {
   });
 };
 
-export const clearDirectory = async (dir: string) => {
-  const files = await getDirectoryContents(dir);
-  for (const file of files) {
-    fs.unlink(path.join(dir, file), err => {
-      if (err) throw err;
-    });
-  }
+export const clearDirectory = async (dir: string): Promise<void> => {
+  const allFiles = await fs.promises.readdir(dir);
+  const files = allFiles.filter(
+    file => file !== 'jpgs' && file.startsWith('.') === false
+  );
+
+  await Promise.all(
+    files.map(file => fs.promises.unlink(path.join(dir, file)))
+  );
 };
 
 export const downloadNewspaperPDFs = async () => {


### PR DESCRIPTION
## Summary
- refactor `clearDirectory` to use async fs API and wait for all deletions

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx prettier -w newspapers.ts` *(fails: Cannot find package 'prettier-airbnb-config')*

------
https://chatgpt.com/codex/tasks/task_e_684744be682c832587a28a7f36bd3103