### PR TITLE
Add setup script and expand documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,34 @@
-## Welcome to meural-newspapers!
-The goal of this project is to fetch newspaper front pages every morning to display on a Meural frame
+# Meural Newspapers
 
-### Prerequisites
-* ImageMagick must be installed on the system, the node package included in this project is just a wrapper. Install via brew or other package manager.
+Fetches newspaper front pages each morning and uploads them to a Meural digital frame.
 
-### To get started
-* Copy the config example, and fill in your Meural credentials: `cp config.example.json config.json`
-* Run `npx tsc && node index.js` to compile and run (for now)
+## Getting Started
 
-Authentication now uses Amazon Cognito via the AWS SDK, mirroring the official
-Meural login flow.
+1. **Install prerequisites**
+   - [Node.js](https://nodejs.org/) and npm
+   - [ImageMagick](https://imagemagick.org/) for PDF to image conversion
 
+2. **Run the setup script**
+   ```sh
+   npm run setup
+   ```
+   This installs dependencies, compiles the TypeScript sources and creates a `config.json` file if one doesn't exist.
+
+3. **Configure credentials**
+   Update `config.json` with your Meural email, password, device alias and gallery name.
+
+4. **Fetch and upload today's newspapers**
+   ```sh
+   npm start
+   ```
+
+## How it Works
+
+- `newspapers.ts` downloads PDF front pages from the Freedom Forum and converts them into images.
+- Image transformation and aspect ratio enforcement are handled with [ImageMagick](https://imagemagick.org/).
+- Authentication mirrors the official Meural login flow using Amazon Cognito (`@aws-sdk/client-cognito-identity-provider`).
+- The `meural.ts` client manages gallery creation, image uploads and pushing content to your device.
+- Concurrency is controlled with `p-limit`, and network requests are performed with `axios`.
+- Logging output is centralized through `logger.ts`.
+
+Enjoy seeing fresh headlines on your Meural frame every day!

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "index.js",
   "prettier": "prettier-airbnb-config",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "setup": "bash setup.sh",
+    "start": "node index.js",
+    "build": "tsc",
+    "test": "tsc --noEmit"
   },
   "author": "Evan Madow",
   "license": "ISC",

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Setting up meural-newspapers..."
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js is required but not installed. Please install Node.js and try again."
+  exit 1
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is required but not installed. Please install npm and try again."
+  exit 1
+fi
+
+if ! command -v convert >/dev/null 2>&1 && ! command -v magick >/dev/null 2>&1; then
+  echo "ImageMagick is required. Install it with your package manager (e.g., 'brew install imagemagick')."
+  exit 1
+fi
+
+echo "Installing Node dependencies..."
+npm install --legacy-peer-deps
+
+if [ ! -f config.json ]; then
+  echo "Creating config.json from template..."
+  cp config.example.json config.json
+  echo "Please edit config.json with your Meural credentials."
+fi
+
+echo "Compiling TypeScript..."
+npx tsc
+
+echo "Setup complete. Run 'npm start' to fetch and upload today's newspapers."


### PR DESCRIPTION
## Summary
- add setup.sh to install dependencies, create config.json, and compile TypeScript
- document setup and architecture in README
- expose npm scripts for setup, build, start, and test

## Testing
- `npm run setup` *(fails: ImageMagick is required)*
- `npm test` *(fails: Cannot find type definition files; dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad36678df48325b51a07f6d44211be